### PR TITLE
Add Simple Calculator Android app

### DIFF
--- a/SimpleCalculatorApp/README.md
+++ b/SimpleCalculatorApp/README.md
@@ -1,0 +1,7 @@
+# Simple Calculator App
+
+This is a minimal Android application that performs addition of two numbers. The app does not require any special permissions or internet connectivity.
+
+## Building
+
+Use Android Studio to open the `SimpleCalculatorApp` folder as a project and build the app.

--- a/SimpleCalculatorApp/app/build.gradle
+++ b/SimpleCalculatorApp/app/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.example.simplecalculator"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}

--- a/SimpleCalculatorApp/app/proguard-rules.pro
+++ b/SimpleCalculatorApp/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules placeholder

--- a/SimpleCalculatorApp/app/src/main/AndroidManifest.xml
+++ b/SimpleCalculatorApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.simplecalculator">
+
+    <application
+        android:allowBackup="true"
+        android:label="Simple Calculator"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/MainActivity.kt
+++ b/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/MainActivity.kt
@@ -1,0 +1,25 @@
+package com.example.simplecalculator
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val num1 = findViewById<EditText>(R.id.editTextNumber1)
+        val num2 = findViewById<EditText>(R.id.editTextNumber2)
+        val resultView = findViewById<TextView>(R.id.textViewResult)
+        val addButton = findViewById<Button>(R.id.buttonAdd)
+
+        addButton.setOnClickListener {
+            val a = num1.text.toString().toDoubleOrNull() ?: 0.0
+            val b = num2.text.toString().toDoubleOrNull() ?: 0.0
+            resultView.text = (a + b).toString()
+        }
+    }
+}

--- a/SimpleCalculatorApp/app/src/main/res/layout/activity_main.xml
+++ b/SimpleCalculatorApp/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/editTextNumber1"
+        android:inputType="numberDecimal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Number 1" />
+
+    <EditText
+        android:id="@+id/editTextNumber2"
+        android:inputType="numberDecimal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Number 2" />
+
+    <Button
+        android:id="@+id/buttonAdd"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Add" />
+
+    <TextView
+        android:id="@+id/textViewResult"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Result"
+        android:textSize="18sp" />
+
+</LinearLayout>

--- a/SimpleCalculatorApp/app/src/main/res/values/strings.xml
+++ b/SimpleCalculatorApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Simple Calculator</string>
+</resources>

--- a/SimpleCalculatorApp/build.gradle
+++ b/SimpleCalculatorApp/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.4.2"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/SimpleCalculatorApp/settings.gradle
+++ b/SimpleCalculatorApp/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = "SimpleCalculator"


### PR DESCRIPTION
## Summary
- add an Android example under `SimpleCalculatorApp`
- include a basic activity and layout performing addition
- provide minimal Gradle configuration
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f56a5fcc8832fba1b4580a5597c5b