### PR TITLE
Add Simple Calculator Android app

### DIFF
--- a/SimpleCalculatorApp/README.md
+++ b/SimpleCalculatorApp/README.md
@@ -1,0 +1,7 @@
+# Simple Calculator App
+
+This is a minimal Android application that performs addition of two numbers. The app does not require any special permissions or internet connectivity.
+
+## Building
+
+Use Android Studio to open the `SimpleCalculatorApp` folder as a project and build the app.

--- a/SimpleCalculatorApp/README.md
+++ b/SimpleCalculatorApp/README.md
@@ -1,7 +1,7 @@
 # Simple Calculator App
 
-This is a minimal Android application that performs addition of two numbers. The app does not require any special permissions or internet connectivity.
+This sample Android application performs basic arithmetic: addition, subtraction, multiplication and division. It requires no special permissions or internet connectivity.
 
 ## Building
 
-Use Android Studio to open the `SimpleCalculatorApp` folder as a project and build the app.
+Open the `SimpleCalculatorApp` directory with Android Studio and build the project. Unit tests covering the calculator logic are included and can be run with the Gradle `test` task.

--- a/SimpleCalculatorApp/app/build.gradle
+++ b/SimpleCalculatorApp/app/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/SimpleCalculatorApp/app/build.gradle
+++ b/SimpleCalculatorApp/app/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.example.simplecalculator"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}

--- a/SimpleCalculatorApp/app/proguard-rules.pro
+++ b/SimpleCalculatorApp/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules placeholder

--- a/SimpleCalculatorApp/app/src/main/AndroidManifest.xml
+++ b/SimpleCalculatorApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.simplecalculator">
+
+    <application
+        android:allowBackup="true"
+        android:label="Simple Calculator"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/Calculator.kt
+++ b/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/Calculator.kt
@@ -1,0 +1,8 @@
+package com.example.simplecalculator
+
+class Calculator {
+    fun add(a: Double, b: Double): Double = a + b
+    fun subtract(a: Double, b: Double): Double = a - b
+    fun multiply(a: Double, b: Double): Double = a * b
+    fun divide(a: Double, b: Double): Double = if (b != 0.0) a / b else Double.NaN
+}

--- a/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/MainActivity.kt
+++ b/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/MainActivity.kt
@@ -1,0 +1,25 @@
+package com.example.simplecalculator
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val num1 = findViewById<EditText>(R.id.editTextNumber1)
+        val num2 = findViewById<EditText>(R.id.editTextNumber2)
+        val resultView = findViewById<TextView>(R.id.textViewResult)
+        val addButton = findViewById<Button>(R.id.buttonAdd)
+
+        addButton.setOnClickListener {
+            val a = num1.text.toString().toDoubleOrNull() ?: 0.0
+            val b = num2.text.toString().toDoubleOrNull() ?: 0.0
+            resultView.text = (a + b).toString()
+        }
+    }
+}

--- a/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/MainActivity.kt
+++ b/SimpleCalculatorApp/app/src/main/java/com/example/simplecalculator/MainActivity.kt
@@ -7,6 +7,8 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+    private val calculator = Calculator()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -14,12 +16,21 @@ class MainActivity : AppCompatActivity() {
         val num1 = findViewById<EditText>(R.id.editTextNumber1)
         val num2 = findViewById<EditText>(R.id.editTextNumber2)
         val resultView = findViewById<TextView>(R.id.textViewResult)
-        val addButton = findViewById<Button>(R.id.buttonAdd)
 
-        addButton.setOnClickListener {
-            val a = num1.text.toString().toDoubleOrNull() ?: 0.0
-            val b = num2.text.toString().toDoubleOrNull() ?: 0.0
-            resultView.text = (a + b).toString()
-        }
+        val addButton = findViewById<Button>(R.id.buttonAdd)
+        val subButton = findViewById<Button>(R.id.buttonSub)
+        val mulButton = findViewById<Button>(R.id.buttonMul)
+        val divButton = findViewById<Button>(R.id.buttonDiv)
+
+        addButton.setOnClickListener { performOperation(num1, num2, resultView) { a, b -> calculator.add(a, b) } }
+        subButton.setOnClickListener { performOperation(num1, num2, resultView) { a, b -> calculator.subtract(a, b) } }
+        mulButton.setOnClickListener { performOperation(num1, num2, resultView) { a, b -> calculator.multiply(a, b) } }
+        divButton.setOnClickListener { performOperation(num1, num2, resultView) { a, b -> calculator.divide(a, b) } }
+    }
+
+    private fun performOperation(num1: EditText, num2: EditText, resultView: TextView, op: (Double, Double) -> Double) {
+        val a = num1.text.toString().toDoubleOrNull() ?: 0.0
+        val b = num2.text.toString().toDoubleOrNull() ?: 0.0
+        resultView.text = op(a, b).toString()
     }
 }

--- a/SimpleCalculatorApp/app/src/main/res/layout/activity_main.xml
+++ b/SimpleCalculatorApp/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/editTextNumber1"
+        android:inputType="numberDecimal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Number 1" />
+
+    <EditText
+        android:id="@+id/editTextNumber2"
+        android:inputType="numberDecimal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Number 2" />
+
+    <Button
+        android:id="@+id/buttonAdd"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Add" />
+
+    <TextView
+        android:id="@+id/textViewResult"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Result"
+        android:textSize="18sp" />
+
+</LinearLayout>

--- a/SimpleCalculatorApp/app/src/main/res/layout/activity_main.xml
+++ b/SimpleCalculatorApp/app/src/main/res/layout/activity_main.xml
@@ -19,11 +19,41 @@
         android:layout_height="wrap_content"
         android:hint="Number 2" />
 
-    <Button
-        android:id="@+id/buttonAdd"
+    <LinearLayout
+        android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Add" />
+        android:layout_height="wrap_content">
+        <Button
+            android:id="@+id/buttonAdd"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="Add" />
+        <Button
+            android:id="@+id/buttonSub"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="Sub" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <Button
+            android:id="@+id/buttonMul"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="Mul" />
+        <Button
+            android:id="@+id/buttonDiv"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="Div" />
+    </LinearLayout>
 
     <TextView
         android:id="@+id/textViewResult"

--- a/SimpleCalculatorApp/app/src/main/res/values/strings.xml
+++ b/SimpleCalculatorApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Simple Calculator</string>
+</resources>

--- a/SimpleCalculatorApp/app/src/test/java/com/example/simplecalculator/CalculatorTest.kt
+++ b/SimpleCalculatorApp/app/src/test/java/com/example/simplecalculator/CalculatorTest.kt
@@ -1,0 +1,28 @@
+package com.example.simplecalculator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CalculatorTest {
+    private val calculator = Calculator()
+
+    @Test
+    fun testAdd() {
+        assertEquals(5.0, calculator.add(2.0, 3.0), 0.0001)
+    }
+
+    @Test
+    fun testSubtract() {
+        assertEquals(1.0, calculator.subtract(3.0, 2.0), 0.0001)
+    }
+
+    @Test
+    fun testMultiply() {
+        assertEquals(6.0, calculator.multiply(2.0, 3.0), 0.0001)
+    }
+
+    @Test
+    fun testDivide() {
+        assertEquals(2.0, calculator.divide(6.0, 3.0), 0.0001)
+    }
+}

--- a/SimpleCalculatorApp/build.gradle
+++ b/SimpleCalculatorApp/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.4.2"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/SimpleCalculatorApp/settings.gradle
+++ b/SimpleCalculatorApp/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = "SimpleCalculator"


### PR DESCRIPTION
## Summary
- add an Android example under `SimpleCalculatorApp`
- include a basic activity and layout performing addition
- provide minimal Gradle configuration
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f56a5fcc8832fba1b4580a5597c5b