### PR TITLE
Add sports streaming channel UI powered by ALL SPORT LIVE STREAM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Sports Streaming Channel (RapidAPI)
+
+Simple frontend app that loads channel stream URLs from:
+
+- `https://all-sport-live-stream.p.rapidapi.com/api/v6/play-stream`
+
+## Run locally
+
+```bash
+python3 -m http.server 4173
+```
+
+Open `http://localhost:4173`, enter your RapidAPI key, and click **Load Channels**.
+
+## Notes
+
+- The app stores your API key in `localStorage` for convenience.
+- Some streams may not play in native browser `<video>` depending on format and CORS.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,168 @@
+const API_URL = 'https://all-sport-live-stream.p.rapidapi.com/api/v6/play-stream';
+const API_HOST = 'all-sport-live-stream.p.rapidapi.com';
+
+const apiKeyInput = document.getElementById('apiKey');
+const loadBtn = document.getElementById('loadBtn');
+const statusEl = document.getElementById('status');
+const channelListEl = document.getElementById('channelList');
+const playerEl = document.getElementById('player');
+const selectedChannelEl = document.getElementById('selectedChannel');
+
+const savedKey = localStorage.getItem('rapidapi-key');
+if (savedKey) {
+  apiKeyInput.value = savedKey;
+}
+
+loadBtn.addEventListener('click', loadChannels);
+
+async function loadChannels() {
+  const apiKey = apiKeyInput.value.trim();
+
+  if (!apiKey) {
+    setStatus('Please enter your x-rapidapi-key first.', true);
+    return;
+  }
+
+  localStorage.setItem('rapidapi-key', apiKey);
+  setStatus('Loading channels...');
+  channelListEl.innerHTML = '';
+  playerEl.removeAttribute('src');
+  selectedChannelEl.textContent = 'No channel selected.';
+
+  try {
+    const response = await fetch(API_URL, {
+      method: 'GET',
+      headers: {
+        'x-rapidapi-key': apiKey,
+        'x-rapidapi-host': API_HOST
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const rawText = await response.text();
+    const payload = safeParseJSON(rawText);
+    const channels = normalizeChannels(payload);
+
+    if (!channels.length) {
+      setStatus('No playable channels were found in the API response.', true);
+      return;
+    }
+
+    renderChannelButtons(channels);
+    selectChannel(channels[0], 0);
+    setStatus(`Loaded ${channels.length} channels.`);
+  } catch (error) {
+    setStatus(`Unable to load channels: ${error.message}`, true);
+  }
+}
+
+function safeParseJSON(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeChannels(payload) {
+  const items = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload?.result)
+        ? payload.result
+        : [payload];
+
+  return items
+    .map((item, index) => {
+      const streamUrl = findStreamUrl(item);
+      if (!streamUrl) {
+        return null;
+      }
+
+      const name =
+        item?.name ||
+        item?.title ||
+        item?.channel ||
+        item?.event ||
+        `Channel ${index + 1}`;
+
+      return { name, streamUrl };
+    })
+    .filter(Boolean);
+}
+
+function findStreamUrl(input) {
+  if (!input) {
+    return null;
+  }
+
+  if (typeof input === 'string') {
+    return isLikelyStreamUrl(input) ? input : null;
+  }
+
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      const nested = findStreamUrl(item);
+      if (nested) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  const preferredFields = ['stream_url', 'url', 'playUrl', 'link', 'm3u8', 'hls'];
+  for (const field of preferredFields) {
+    const value = input[field];
+    if (typeof value === 'string' && isLikelyStreamUrl(value)) {
+      return value;
+    }
+  }
+
+  for (const value of Object.values(input)) {
+    const nested = findStreamUrl(value);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function isLikelyStreamUrl(value) {
+  return /^https?:\/\//i.test(value);
+}
+
+function renderChannelButtons(channels) {
+  channelListEl.innerHTML = '';
+  channels.forEach((channel, index) => {
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.className = 'channel-btn';
+    button.textContent = channel.name;
+    button.addEventListener('click', () => selectChannel(channel, index));
+    li.append(button);
+    channelListEl.append(li);
+  });
+}
+
+function selectChannel(channel, index) {
+  playerEl.src = channel.streamUrl;
+  playerEl.play().catch(() => {
+    // Autoplay can be blocked by browser policies.
+  });
+
+  selectedChannelEl.textContent = `${channel.name}: ${channel.streamUrl}`;
+
+  [...document.querySelectorAll('.channel-btn')].forEach((btn, btnIndex) => {
+    btn.classList.toggle('active', btnIndex === index);
+  });
+}
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? '#ff7b72' : '#8b949e';
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>All Sport Live Stream Channel</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>All Sport Live Stream Channel</h1>
+        <p>Load sports streams from the ALL SPORT LIVE STREAM RapidAPI endpoint.</p>
+      </header>
+
+      <section class="controls">
+        <label for="apiKey">RapidAPI Key</label>
+        <input id="apiKey" type="password" placeholder="Enter x-rapidapi-key" />
+        <button id="loadBtn" type="button">Load Channels</button>
+      </section>
+
+      <section class="status" id="status">Enter your API key and load channels.</section>
+
+      <section class="content">
+        <aside>
+          <h2>Available Channels</h2>
+          <ul id="channelList"></ul>
+        </aside>
+        <section class="playerArea">
+          <h2>Player</h2>
+          <video id="player" controls playsinline></video>
+          <p id="selectedChannel">No channel selected.</p>
+        </section>
+      </section>
+    </main>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,125 @@
+:root {
+  color-scheme: dark;
+  --bg: #0e1117;
+  --card: #161b22;
+  --text: #c9d1d9;
+  --muted: #8b949e;
+  --accent: #2f81f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+header h1 {
+  margin-bottom: 0.25rem;
+}
+
+header p {
+  margin-top: 0;
+  color: var(--muted);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin: 1rem 0;
+}
+
+input,
+button {
+  border-radius: 8px;
+  border: 1px solid #30363d;
+  background: var(--card);
+  color: var(--text);
+  padding: 0.6rem 0.8rem;
+}
+
+input {
+  min-width: 320px;
+}
+
+button {
+  background: var(--accent);
+  border-color: transparent;
+  cursor: pointer;
+}
+
+.status {
+  background: var(--card);
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem;
+  color: var(--muted);
+}
+
+.content {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 1rem;
+}
+
+aside,
+.playerArea {
+  background: var(--card);
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+#channelList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 420px;
+  overflow: auto;
+}
+
+.channel-btn {
+  width: 100%;
+  text-align: left;
+  background: #21262d;
+}
+
+.channel-btn.active {
+  outline: 2px solid var(--accent);
+}
+
+#player {
+  width: 100%;
+  min-height: 320px;
+  background: #000;
+  border-radius: 8px;
+}
+
+#selectedChannel {
+  color: var(--muted);
+}
+
+@media (max-width: 880px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  input {
+    min-width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a small single-page frontend that can load sports stream URLs from the ALL SPORT LIVE STREAM RapidAPI endpoint and let users browse and play channels. 
- Make the client robust to different API response shapes by normalizing arrays/objects and discovering stream URLs in nested payloads. 
- Offer a minimal, responsive dark-themed UI with an embedded player and convenience features like storing the RapidAPI key in `localStorage`.

### Description
- Add `index.html`, `styles.css`, and `app.js` to implement the single-page UI with a RapidAPI key input, "Load Channels" button, channel list, and video player. 
- Implement channel normalization and recursive stream URL discovery in `app.js` to handle responses shaped as arrays, `{ data }`, `{ result }`, or nested objects, and to pick common fields like `stream_url`, `url`, `m3u8`, and `hls`. 
- Persist the RapidAPI key to `localStorage`, render selectable channel buttons that highlight the active channel, and set the player `src` to the selected stream URL with a best-effort `play()` call. 
- Add `README.md` with local run instructions (`python3 -m http.server 4173`) and usage/notes about playback and CORS limitations.

### Testing
- `node --check app.js` was run and succeeded. 
- A local static server was launched with `python3 -m http.server 4173 --bind 0.0.0.0` to serve the UI and this started successfully. 
- A Playwright script visited the running server and captured a UI screenshot, which completed successfully. 
- A `curl -I http://127.0.0.1:4173` attempt failed to connect in an earlier ephemeral server attempt, and an attempted `python3 -m py_compile` invocation was mis-specified and failed, but the later server and browser validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a90ddf8fc832f987fdc5d2e272ff4)